### PR TITLE
Fix duplicated ANSI color code in output

### DIFF
--- a/bin/meow.ps1
+++ b/bin/meow.ps1
@@ -1,5 +1,41 @@
 #!/usr/bin/env pwsh
 
+<#
+.SYNOPSIS
+meow(1) - A minimalistic `lolcat` clone for Windows that actually works.
+.DESCRIPTION
+meow(1) is a `lolcat` clone written in Pure PowerShell. It is a simple utility that rainbowizes text in the terminal.
+.PARAMETER text
+The file or text to read from.
+.PARAMETER spread
+The color spread of the rainbow.
+.PARAMETER frequency
+Specify a color frequency
+.PARAMETER invert
+Invert the background and foreground colors.
+.PARAMETER demo
+Run a demo of meow(1).
+.PARAMETER help
+Display the help message in rainbow colors.
+.EXAMPLE
+"Hello, World!" | meow
+.NOTES
+Copyright 2018 - 2024 Kied Llaetenn AGPL-3.0
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR ANY PARTICULAR PURPOSE.  See the
+GNU Affero General Public License v3 for more details.
+.LINK
+https://github.com/kiedtl/meow
+.LINK
+https://github.com/js0ny/TyanCat/tree/bmeow
+#>
 param (
     [Parameter(
         ValueFromPipeline = $true

--- a/bin/meow.ps1
+++ b/bin/meow.ps1
@@ -33,7 +33,8 @@ process {
     if ($help  ) { meow_internal_help	 ;	break }
     if ($invert) { $escapeseq = "48" }
     write-host "$E[?25l" -nonewline
-
+    $ANSI_REGEX = "`e\[[0-9;?]*[A-Za-z]"
+    $text = $text -Replace $ANSI_REGEX,""
     $text | out-string | meow_execute -Spread $spread -Freq $frequency -Escape $escapeseq
 
     $E = [char]27

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -21,7 +21,7 @@ function meow_execute {
     [int]$r = ([math]::sin($Freq * ($script:i / $Spread) + 0) * 127 + 128)
     [int]$g = ([math]::sin($Freq * ($script:i / $Spread) + 2 * [math]::pi / 3) * 127 + 128)
     [int]$b = ([math]::sin($Freq * ($script:i / $Spread) + 4 * [math]::pi / 3) * 127 + 128)
-    $c_txt | % {
+    $c_txt | ForEach-Object {
         write-host "$E[${Escape};2;${r};${g};${b}m$_$E[0m" -nonewline
         [bool]$isWhitespace = if ($_ -eq " ") { $true } else { $false }
         if ($_ -eq "`n") {
@@ -40,7 +40,7 @@ function meow_execute {
 function meow_internal_demo {
 	$i = 0
 	$s = ""
-	1..102 | % {
+	1..102 | ForEach-Object {
 		$s += "Hello, World!"
 		$i++
 		if ($i -gt 5) {


### PR DESCRIPTION
If the input content itself contains ANSI color code, remove it for not displaying them out.

![image](https://github.com/user-attachments/assets/7370d534-310b-45b9-abb3-74070acf0ee7)


Add Comment-Based Help in the main `meow` file so that `Get-Help` works for `meow`

![image](https://github.com/user-attachments/assets/d4844ad7-7b5e-4cd3-a4f5-c784dfbeffbf)


## Related Issues

Close #2 